### PR TITLE
Use crypto.randomBytes for nonce generation

### DIFF
--- a/src/client/ApiXRequest.ts
+++ b/src/client/ApiXRequest.ts
@@ -12,7 +12,7 @@ import { ApiXKeyStore } from './security/ApiXKeyStore';
 import { ApiXRequestConfig } from './types/ApiXRequestConfig';
 import { ApiXRequestError } from './error';
 import { ApiXResponse } from './types/ApiXResponse';
-import { createHmac } from 'crypto';
+import { createHmac, randomBytes } from 'crypto';
 
 /**
  * Headers that can be set on an API-X request.
@@ -376,12 +376,13 @@ export class ApiXRequest {
 
   private generateNonce(length: number = 16): string {
     const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-      let nonce = '';
-      for (let i = 0; i < length; i++) {
-        const randomIndex = Math.floor(Math.random() * characters.length);
-        nonce += characters[randomIndex];
-      }
-      return nonce;
+    const bytes = randomBytes(length);
+    let nonce = '';
+    for (let i = 0; i < bytes.length; i++) {
+      const randomIndex = bytes[i] % characters.length;
+      nonce += characters[randomIndex];
+    }
+    return nonce;
   }
 
   private generateSignature(appKey: string, dateString: string, nonce: string) {


### PR DESCRIPTION
## Summary
- generate request nonces with `crypto.randomBytes`
- keep nonce length checks in tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68728650b4e883309d1e45c0084c551b