### PR TITLE
Fix header cleanup

### DIFF
--- a/src/client/ApiXRequest.ts
+++ b/src/client/ApiXRequest.ts
@@ -143,7 +143,7 @@ export class ApiXRequest {
    * Unsets the protected headers for the request.
    */
   private unsetProtectedHeaders() {
-    delete this.readOnlyHeaders[this.headerName(ProtectedHeaders.ApiKey)];
+    delete this.protectedHeaders[this.headerName(ProtectedHeaders.ApiKey)];
     delete this.protectedHeaders[this.headerName(ProtectedHeaders.Signature)];
     delete this.protectedHeaders[this.headerName(ProtectedHeaders.SignatureNonce)];
   }

--- a/src/client/__tests__/ApiXRequest.test.ts
+++ b/src/client/__tests__/ApiXRequest.test.ts
@@ -32,17 +32,18 @@ describe('ApiXRequest', () => {
     expect(request.httpMethod).toBe('POST');
   });
 
-  it('protected headers must not be set after making request', async () => {
+  it('protected headers must be cleared after making request', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       status: 200,
       json: jest.fn().mockResolvedValue({ success: true })
     });
 
     await request.make();
-    const headers = request.headers;
-    expect(headers['x-api-key']).toBeUndefined();
-    expect(headers['x-signature']).toBeUndefined();
-    expect(headers['x-signature-nonce']).toBeUndefined();
+
+    const protectedHeaders = (request as any).protectedHeaders;
+    expect(protectedHeaders['x-api-key']).toBeUndefined();
+    expect(protectedHeaders['x-signature']).toBeUndefined();
+    expect(protectedHeaders['x-signature-nonce']).toBeUndefined();
   });
 
   it('should initialize read-only headers properly.', async () => {


### PR DESCRIPTION
## Summary
- ensure `unsetProtectedHeaders()` removes the API key
- verify protected header store cleanup

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6872864e6fdc8330a2c445167a2128f5